### PR TITLE
Automatically generate index file

### DIFF
--- a/genversions.py
+++ b/genversions.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 import copy
 import glob
 import jinja2
+import os
 
 tpl_str = """
 <div id="cvc5-versions" class="rst-versions shift-up" data-toggle="rst-versions" role="note" aria-label="versions">
@@ -79,6 +80,7 @@ for version in versions:
     for file in list_files(f'docs-{version}'):
         put_versions_in_file(file, copy.copy(newvers))
 
-latest_version = sorted(versions)[-1]
+stat_versions = map(lambda v: (os.stat(v).st_mtime, v), versions)
+latest_version = sorted(stat_versions)[-1][1]
 newindex = tpl_redirect.render(release=latest_version)
 open("index.html", 'w').write(newindex)

--- a/genversions.py
+++ b/genversions.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup
 import copy
 import glob
 import jinja2
-import os
+import re
 
 tpl_str = """
 <div id="cvc5-versions" class="rst-versions shift-up" data-toggle="rst-versions" role="note" aria-label="versions">
@@ -44,7 +44,7 @@ def put_versions_in_file(filename, newblock):
     nav = doc.find('nav', class_='wy-nav-side')
     if not nav:
         return
-    
+
     # find relative path to root dir
     urlroot = doc.find('script', id='documentation_options')
     if not urlroot:
@@ -52,7 +52,7 @@ def put_versions_in_file(filename, newblock):
     urlroot = f'{urlroot["data-url_root"]}..'
     for a in newblock.find_all('a'):
         a['href'] = a['href'].replace('%URLROOT%', urlroot)
-    
+
     cur = nav.find(id='cvc5-versions')
     if cur:
         cur.replace_with(newblock)
@@ -80,7 +80,12 @@ for version in versions:
     for file in list_files(f'docs-{version}'):
         put_versions_in_file(file, copy.copy(newvers))
 
-stat_versions = map(lambda v: (os.stat(v).st_mtime, v), versions)
-latest_version = sorted(stat_versions)[-1][1]
+# map "cvc5-x.y.z" to (x, y, z, "cvc5-x.y.z")
+stat_versions = map(
+    lambda v:
+    (*map(int,
+          re.match('cvc5-([0-9]+).([0-9]+).([0-9]+)', v).groups()), v),
+    versions)
+latest_version = sorted(stat_versions)[-1][-1]
 newindex = tpl_redirect.render(release=latest_version)
 open("index.html", 'w').write(newindex)

--- a/genversions.py
+++ b/genversions.py
@@ -25,6 +25,15 @@ tpl_str = """
 """
 tpl = jinja2.Template(tpl_str)
 
+tpl_redirect_str = """
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirect to latest release</title>
+<meta http-equiv="refresh" content="0; URL={{ release }}/">
+<link rel="canonical" href="{{ release }}/">
+"""
+tpl_redirect = jinja2.Template(tpl_redirect_str)
+
 
 def put_versions_in_file(filename, newblock):
     """Insert or replace the `cvc5-versions` block with the new block."""
@@ -53,7 +62,7 @@ def put_versions_in_file(filename, newblock):
 
 def collect_versions():
     """Collect all paths / versions."""
-    return ['master', *glob.iglob('cvc5-*')]
+    return glob.glob('cvc5-*')
 
 
 def list_files(basepath):
@@ -69,3 +78,7 @@ for version in versions:
 
     for file in list_files(f'docs-{version}'):
         put_versions_in_file(file, copy.copy(newvers))
+
+latest_version = sorted(versions)[-1]
+newindex = tpl_redirect.render(release=latest_version)
+open("index.html", 'w').write(newindex)


### PR DESCRIPTION
This automatically generates an index file that redirects to the last release. Identifying the latest release is slightly more complicated than sorting by name so ensure that `0.0.10 > 0.0.7`.