### PR TITLE
Add link to latest version of documentation

### DIFF
--- a/cvc5-1.0.0/api/api.html
+++ b/cvc5-1.0.0/api/api.html
@@ -136,6 +136,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -146,11 +156,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/cpp.html
+++ b/cvc5-1.0.0/api/cpp/cpp.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/datatype.html
+++ b/cvc5-1.0.0/api/cpp/datatype.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/datatypeconstructor.html
+++ b/cvc5-1.0.0/api/cpp/datatypeconstructor.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/datatypeconstructordecl.html
+++ b/cvc5-1.0.0/api/cpp/datatypeconstructordecl.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/datatypedecl.html
+++ b/cvc5-1.0.0/api/cpp/datatypedecl.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/datatypeselector.html
+++ b/cvc5-1.0.0/api/cpp/datatypeselector.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/driveroptions.html
+++ b/cvc5-1.0.0/api/cpp/driveroptions.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/exceptions.html
+++ b/cvc5-1.0.0/api/cpp/exceptions.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/grammar.html
+++ b/cvc5-1.0.0/api/cpp/grammar.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/kind.html
+++ b/cvc5-1.0.0/api/cpp/kind.html
@@ -253,6 +253,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -263,11 +273,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/modes.html
+++ b/cvc5-1.0.0/api/cpp/modes.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/op.html
+++ b/cvc5-1.0.0/api/cpp/op.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/optioninfo.html
+++ b/cvc5-1.0.0/api/cpp/optioninfo.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/quickstart.html
+++ b/cvc5-1.0.0/api/cpp/quickstart.html
@@ -262,6 +262,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -272,11 +282,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/result.html
+++ b/cvc5-1.0.0/api/cpp/result.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/roundingmode.html
+++ b/cvc5-1.0.0/api/cpp/roundingmode.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/solver.html
+++ b/cvc5-1.0.0/api/cpp/solver.html
@@ -253,6 +253,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -263,11 +273,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/sort.html
+++ b/cvc5-1.0.0/api/cpp/sort.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/statistics.html
+++ b/cvc5-1.0.0/api/cpp/statistics.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/synthresult.html
+++ b/cvc5-1.0.0/api/cpp/synthresult.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/term.html
+++ b/cvc5-1.0.0/api/cpp/term.html
@@ -253,6 +253,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -263,11 +273,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/cpp/unknownexplanation.html
+++ b/cvc5-1.0.0/api/cpp/unknownexplanation.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -258,11 +268,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/java/java.html
+++ b/cvc5-1.0.0/api/java/java.html
@@ -158,6 +158,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -168,11 +178,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/java/quickstart.html
+++ b/cvc5-1.0.0/api/java/quickstart.html
@@ -172,6 +172,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -182,11 +192,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/datatype.html
+++ b/cvc5-1.0.0/api/python/base/datatype.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/datatypeconstructor.html
+++ b/cvc5-1.0.0/api/python/base/datatypeconstructor.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/datatypeconstructordecl.html
+++ b/cvc5-1.0.0/api/python/base/datatypeconstructordecl.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/datatypedecl.html
+++ b/cvc5-1.0.0/api/python/base/datatypedecl.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/datatypeselector.html
+++ b/cvc5-1.0.0/api/python/base/datatypeselector.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/grammar.html
+++ b/cvc5-1.0.0/api/python/base/grammar.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/kind.html
+++ b/cvc5-1.0.0/api/python/base/kind.html
@@ -250,6 +250,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -260,11 +270,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/op.html
+++ b/cvc5-1.0.0/api/python/base/op.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/python.html
+++ b/cvc5-1.0.0/api/python/base/python.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/quickstart.html
+++ b/cvc5-1.0.0/api/python/base/quickstart.html
@@ -259,6 +259,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -269,11 +279,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/result.html
+++ b/cvc5-1.0.0/api/python/base/result.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/roundingmode.html
+++ b/cvc5-1.0.0/api/python/base/roundingmode.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/solver.html
+++ b/cvc5-1.0.0/api/python/base/solver.html
@@ -250,6 +250,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -260,11 +270,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/sort.html
+++ b/cvc5-1.0.0/api/python/base/sort.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/statistics.html
+++ b/cvc5-1.0.0/api/python/base/statistics.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/synthresult.html
+++ b/cvc5-1.0.0/api/python/base/synthresult.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/term.html
+++ b/cvc5-1.0.0/api/python/base/term.html
@@ -250,6 +250,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -260,11 +270,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/base/unknownexplanation.html
+++ b/cvc5-1.0.0/api/python/base/unknownexplanation.html
@@ -245,6 +245,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -255,11 +265,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/python.html
+++ b/cvc5-1.0.0/api/python/python.html
@@ -158,6 +158,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -168,11 +178,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/arith.html
+++ b/cvc5-1.0.0/api/python/pythonic/arith.html
@@ -247,6 +247,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -257,11 +267,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/array.html
+++ b/cvc5-1.0.0/api/python/pythonic/array.html
@@ -237,6 +237,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -247,11 +257,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/bitvec.html
+++ b/cvc5-1.0.0/api/python/pythonic/bitvec.html
@@ -242,6 +242,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -252,11 +262,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/boolean.html
+++ b/cvc5-1.0.0/api/python/pythonic/boolean.html
@@ -247,6 +247,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -257,11 +267,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/dt.html
+++ b/cvc5-1.0.0/api/python/pythonic/dt.html
@@ -232,6 +232,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -242,11 +252,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/fp.html
+++ b/cvc5-1.0.0/api/python/pythonic/fp.html
@@ -242,6 +242,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -252,11 +262,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/internals.html
+++ b/cvc5-1.0.0/api/python/pythonic/internals.html
@@ -227,6 +227,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -237,11 +247,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/pythonic.html
+++ b/cvc5-1.0.0/api/python/pythonic/pythonic.html
@@ -215,6 +215,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -225,11 +235,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/quant.html
+++ b/cvc5-1.0.0/api/python/pythonic/quant.html
@@ -232,6 +232,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -242,11 +252,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/quickstart.html
+++ b/cvc5-1.0.0/api/python/pythonic/quickstart.html
@@ -229,6 +229,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -239,11 +249,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/set.html
+++ b/cvc5-1.0.0/api/python/pythonic/set.html
@@ -232,6 +232,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -242,11 +252,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/api/python/pythonic/solver.html
+++ b/cvc5-1.0.0/api/python/pythonic/solver.html
@@ -237,6 +237,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -247,11 +257,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/binary/binary.html
+++ b/cvc5-1.0.0/binary/binary.html
@@ -126,6 +126,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -136,11 +146,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/binary/quickstart.html
+++ b/cvc5-1.0.0/binary/quickstart.html
@@ -140,6 +140,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -150,11 +160,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/bags.html
+++ b/cvc5-1.0.0/examples/bags.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/bitvectors.html
+++ b/cvc5-1.0.0/examples/bitvectors.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/bitvectors_and_arrays.html
+++ b/cvc5-1.0.0/examples/bitvectors_and_arrays.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/combination.html
+++ b/cvc5-1.0.0/examples/combination.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/datatypes.html
+++ b/cvc5-1.0.0/examples/datatypes.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/examples.html
+++ b/cvc5-1.0.0/examples/examples.html
@@ -216,6 +216,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -226,11 +236,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/exceptions.html
+++ b/cvc5-1.0.0/examples/exceptions.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/extract.html
+++ b/cvc5-1.0.0/examples/extract.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/floatingpoint.html
+++ b/cvc5-1.0.0/examples/floatingpoint.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/helloworld.html
+++ b/cvc5-1.0.0/examples/helloworld.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/lineararith.html
+++ b/cvc5-1.0.0/examples/lineararith.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/quickstart.html
+++ b/cvc5-1.0.0/examples/quickstart.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/relations.html
+++ b/cvc5-1.0.0/examples/relations.html
@@ -223,6 +223,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -233,11 +243,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/sequences.html
+++ b/cvc5-1.0.0/examples/sequences.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/sets.html
+++ b/cvc5-1.0.0/examples/sets.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/strings.html
+++ b/cvc5-1.0.0/examples/strings.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/sygus-fun.html
+++ b/cvc5-1.0.0/examples/sygus-fun.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/sygus-grammar.html
+++ b/cvc5-1.0.0/examples/sygus-grammar.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/examples/sygus-inv.html
+++ b/cvc5-1.0.0/examples/sygus-inv.html
@@ -218,6 +218,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -228,11 +238,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/genindex.html
+++ b/cvc5-1.0.0/genindex.html
@@ -118,6 +118,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -128,11 +138,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/index.html
+++ b/cvc5-1.0.0/index.html
@@ -118,6 +118,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -128,11 +138,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/installation/installation.html
+++ b/cvc5-1.0.0/installation/installation.html
@@ -266,6 +266,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -276,11 +286,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/options.html
+++ b/cvc5-1.0.0/options.html
@@ -233,6 +233,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -243,11 +253,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/output-tags.html
+++ b/cvc5-1.0.0/output-tags.html
@@ -166,6 +166,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -176,11 +186,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/proofs/output_alethe.html
+++ b/cvc5-1.0.0/proofs/output_alethe.html
@@ -141,6 +141,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -151,11 +161,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/proofs/output_dot.html
+++ b/cvc5-1.0.0/proofs/output_dot.html
@@ -141,6 +141,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -151,11 +161,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/proofs/output_lfsc.html
+++ b/cvc5-1.0.0/proofs/output_lfsc.html
@@ -141,6 +141,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -151,11 +161,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/proofs/proof_rules.html
+++ b/cvc5-1.0.0/proofs/proof_rules.html
@@ -146,6 +146,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -156,11 +166,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/proofs/proofs.html
+++ b/cvc5-1.0.0/proofs/proofs.html
@@ -141,6 +141,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -151,11 +161,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/references.html
+++ b/cvc5-1.0.0/references.html
@@ -119,6 +119,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -129,11 +139,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/resource-limits.html
+++ b/cvc5-1.0.0/resource-limits.html
@@ -135,6 +135,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -145,11 +155,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/search.html
+++ b/cvc5-1.0.0/search.html
@@ -122,6 +122,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -132,11 +142,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/statistics.html
+++ b/cvc5-1.0.0/statistics.html
@@ -119,6 +119,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="./../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -129,11 +139,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/bags.html
+++ b/cvc5-1.0.0/theories/bags.html
@@ -184,6 +184,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -194,11 +204,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/datatypes.html
+++ b/cvc5-1.0.0/theories/datatypes.html
@@ -215,6 +215,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -225,11 +235,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/separation-logic.html
+++ b/cvc5-1.0.0/theories/separation-logic.html
@@ -190,6 +190,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -200,11 +210,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/sequences.html
+++ b/cvc5-1.0.0/theories/sequences.html
@@ -180,6 +180,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -190,11 +200,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/sets-and-relations.html
+++ b/cvc5-1.0.0/theories/sets-and-relations.html
@@ -184,6 +184,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -194,11 +204,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/theories.html
+++ b/cvc5-1.0.0/theories/theories.html
@@ -200,6 +200,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -210,11 +220,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.0/theories/transcendentals.html
+++ b/cvc5-1.0.0/theories/transcendentals.html
@@ -192,6 +192,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <a href="../../cvc5-1.0.1/">
          cvc5-1.0.1
         </a>
@@ -202,11 +212,6 @@
           cvc5-1.0.0
          </a>
         </strong>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
-        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.1/api/api.html
+++ b/cvc5-1.0.1/api/api.html
@@ -142,6 +142,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -151,11 +161,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/cpp.html
+++ b/cvc5-1.0.1/api/cpp/cpp.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/datatype.html
+++ b/cvc5-1.0.1/api/cpp/datatype.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/datatypeconstructor.html
+++ b/cvc5-1.0.1/api/cpp/datatypeconstructor.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/datatypeconstructordecl.html
+++ b/cvc5-1.0.1/api/cpp/datatypeconstructordecl.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/datatypedecl.html
+++ b/cvc5-1.0.1/api/cpp/datatypedecl.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/datatypeselector.html
+++ b/cvc5-1.0.1/api/cpp/datatypeselector.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/driveroptions.html
+++ b/cvc5-1.0.1/api/cpp/driveroptions.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/exceptions.html
+++ b/cvc5-1.0.1/api/cpp/exceptions.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/grammar.html
+++ b/cvc5-1.0.1/api/cpp/grammar.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/kind.html
+++ b/cvc5-1.0.1/api/cpp/kind.html
@@ -259,6 +259,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -268,11 +278,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/modes.html
+++ b/cvc5-1.0.1/api/cpp/modes.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/op.html
+++ b/cvc5-1.0.1/api/cpp/op.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/optioninfo.html
+++ b/cvc5-1.0.1/api/cpp/optioninfo.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/quickstart.html
+++ b/cvc5-1.0.1/api/cpp/quickstart.html
@@ -268,6 +268,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -277,11 +287,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/result.html
+++ b/cvc5-1.0.1/api/cpp/result.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/roundingmode.html
+++ b/cvc5-1.0.1/api/cpp/roundingmode.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/solver.html
+++ b/cvc5-1.0.1/api/cpp/solver.html
@@ -259,6 +259,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -268,11 +278,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/sort.html
+++ b/cvc5-1.0.1/api/cpp/sort.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/statistics.html
+++ b/cvc5-1.0.1/api/cpp/statistics.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/synthresult.html
+++ b/cvc5-1.0.1/api/cpp/synthresult.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/term.html
+++ b/cvc5-1.0.1/api/cpp/term.html
@@ -259,6 +259,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -268,11 +278,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/cpp/unknownexplanation.html
+++ b/cvc5-1.0.1/api/cpp/unknownexplanation.html
@@ -254,6 +254,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -263,11 +273,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/java/java.html
+++ b/cvc5-1.0.1/api/java/java.html
@@ -164,6 +164,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -173,11 +183,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/java/quickstart.html
+++ b/cvc5-1.0.1/api/java/quickstart.html
@@ -178,6 +178,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -187,11 +197,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/datatype.html
+++ b/cvc5-1.0.1/api/python/base/datatype.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/datatypeconstructor.html
+++ b/cvc5-1.0.1/api/python/base/datatypeconstructor.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/datatypeconstructordecl.html
+++ b/cvc5-1.0.1/api/python/base/datatypeconstructordecl.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/datatypedecl.html
+++ b/cvc5-1.0.1/api/python/base/datatypedecl.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/datatypeselector.html
+++ b/cvc5-1.0.1/api/python/base/datatypeselector.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/grammar.html
+++ b/cvc5-1.0.1/api/python/base/grammar.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/kind.html
+++ b/cvc5-1.0.1/api/python/base/kind.html
@@ -256,6 +256,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -265,11 +275,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/op.html
+++ b/cvc5-1.0.1/api/python/base/op.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/python.html
+++ b/cvc5-1.0.1/api/python/base/python.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/quickstart.html
+++ b/cvc5-1.0.1/api/python/base/quickstart.html
@@ -265,6 +265,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -274,11 +284,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/result.html
+++ b/cvc5-1.0.1/api/python/base/result.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/roundingmode.html
+++ b/cvc5-1.0.1/api/python/base/roundingmode.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/solver.html
+++ b/cvc5-1.0.1/api/python/base/solver.html
@@ -256,6 +256,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -265,11 +275,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/sort.html
+++ b/cvc5-1.0.1/api/python/base/sort.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/statistics.html
+++ b/cvc5-1.0.1/api/python/base/statistics.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/synthresult.html
+++ b/cvc5-1.0.1/api/python/base/synthresult.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/term.html
+++ b/cvc5-1.0.1/api/python/base/term.html
@@ -256,6 +256,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -265,11 +275,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/base/unknownexplanation.html
+++ b/cvc5-1.0.1/api/python/base/unknownexplanation.html
@@ -251,6 +251,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -260,11 +270,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/python.html
+++ b/cvc5-1.0.1/api/python/python.html
@@ -164,6 +164,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -173,11 +183,6 @@
        <dd>
         <a href="../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/arith.html
+++ b/cvc5-1.0.1/api/python/pythonic/arith.html
@@ -253,6 +253,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -262,11 +272,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/array.html
+++ b/cvc5-1.0.1/api/python/pythonic/array.html
@@ -243,6 +243,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -252,11 +262,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/bitvec.html
+++ b/cvc5-1.0.1/api/python/pythonic/bitvec.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -257,11 +267,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/boolean.html
+++ b/cvc5-1.0.1/api/python/pythonic/boolean.html
@@ -253,6 +253,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -262,11 +272,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/dt.html
+++ b/cvc5-1.0.1/api/python/pythonic/dt.html
@@ -238,6 +238,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -247,11 +257,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/fp.html
+++ b/cvc5-1.0.1/api/python/pythonic/fp.html
@@ -248,6 +248,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -257,11 +267,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/internals.html
+++ b/cvc5-1.0.1/api/python/pythonic/internals.html
@@ -233,6 +233,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -242,11 +252,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/pythonic.html
+++ b/cvc5-1.0.1/api/python/pythonic/pythonic.html
@@ -221,6 +221,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -230,11 +240,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/quant.html
+++ b/cvc5-1.0.1/api/python/pythonic/quant.html
@@ -238,6 +238,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -247,11 +257,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/quickstart.html
+++ b/cvc5-1.0.1/api/python/pythonic/quickstart.html
@@ -235,6 +235,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -244,11 +254,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/set.html
+++ b/cvc5-1.0.1/api/python/pythonic/set.html
@@ -238,6 +238,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -247,11 +257,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/api/python/pythonic/solver.html
+++ b/cvc5-1.0.1/api/python/pythonic/solver.html
@@ -243,6 +243,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -252,11 +262,6 @@
        <dd>
         <a href="../../../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/binary/binary.html
+++ b/cvc5-1.0.1/binary/binary.html
@@ -132,6 +132,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -141,11 +151,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/binary/quickstart.html
+++ b/cvc5-1.0.1/binary/quickstart.html
@@ -146,6 +146,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -155,11 +165,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/bags.html
+++ b/cvc5-1.0.1/examples/bags.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/bitvectors.html
+++ b/cvc5-1.0.1/examples/bitvectors.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/bitvectors_and_arrays.html
+++ b/cvc5-1.0.1/examples/bitvectors_and_arrays.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/combination.html
+++ b/cvc5-1.0.1/examples/combination.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/datatypes.html
+++ b/cvc5-1.0.1/examples/datatypes.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/examples.html
+++ b/cvc5-1.0.1/examples/examples.html
@@ -222,6 +222,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -231,11 +241,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/exceptions.html
+++ b/cvc5-1.0.1/examples/exceptions.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/extract.html
+++ b/cvc5-1.0.1/examples/extract.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/floatingpoint.html
+++ b/cvc5-1.0.1/examples/floatingpoint.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/helloworld.html
+++ b/cvc5-1.0.1/examples/helloworld.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/lineararith.html
+++ b/cvc5-1.0.1/examples/lineararith.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/quickstart.html
+++ b/cvc5-1.0.1/examples/quickstart.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/relations.html
+++ b/cvc5-1.0.1/examples/relations.html
@@ -229,6 +229,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -238,11 +248,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/sequences.html
+++ b/cvc5-1.0.1/examples/sequences.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/sets.html
+++ b/cvc5-1.0.1/examples/sets.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/strings.html
+++ b/cvc5-1.0.1/examples/strings.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/sygus-fun.html
+++ b/cvc5-1.0.1/examples/sygus-fun.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/sygus-grammar.html
+++ b/cvc5-1.0.1/examples/sygus-grammar.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/examples/sygus-inv.html
+++ b/cvc5-1.0.1/examples/sygus-inv.html
@@ -224,6 +224,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -233,11 +243,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/genindex.html
+++ b/cvc5-1.0.1/genindex.html
@@ -124,6 +124,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -133,11 +143,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/index.html
+++ b/cvc5-1.0.1/index.html
@@ -124,6 +124,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -133,11 +143,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/installation/installation.html
+++ b/cvc5-1.0.1/installation/installation.html
@@ -272,6 +272,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -281,11 +291,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/options.html
+++ b/cvc5-1.0.1/options.html
@@ -244,6 +244,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -253,11 +263,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/output-tags.html
+++ b/cvc5-1.0.1/output-tags.html
@@ -177,6 +177,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -186,11 +196,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/proofs/output_alethe.html
+++ b/cvc5-1.0.1/proofs/output_alethe.html
@@ -147,6 +147,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -156,11 +166,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/proofs/output_dot.html
+++ b/cvc5-1.0.1/proofs/output_dot.html
@@ -147,6 +147,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -156,11 +166,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/proofs/output_lfsc.html
+++ b/cvc5-1.0.1/proofs/output_lfsc.html
@@ -147,6 +147,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -156,11 +166,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/proofs/proof_rules.html
+++ b/cvc5-1.0.1/proofs/proof_rules.html
@@ -152,6 +152,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -161,11 +171,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/proofs/proofs.html
+++ b/cvc5-1.0.1/proofs/proofs.html
@@ -147,6 +147,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -156,11 +166,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/references.html
+++ b/cvc5-1.0.1/references.html
@@ -125,6 +125,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -134,11 +144,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/resource-limits.html
+++ b/cvc5-1.0.1/resource-limits.html
@@ -141,6 +141,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -150,11 +160,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/search.html
+++ b/cvc5-1.0.1/search.html
@@ -128,6 +128,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -137,11 +147,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/statistics.html
+++ b/cvc5-1.0.1/statistics.html
@@ -125,6 +125,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="./../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -134,11 +144,6 @@
        <dd>
         <a href="./../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/bags.html
+++ b/cvc5-1.0.1/theories/bags.html
@@ -195,6 +195,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -204,11 +214,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/datatypes.html
+++ b/cvc5-1.0.1/theories/datatypes.html
@@ -226,6 +226,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -235,11 +245,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/separation-logic.html
+++ b/cvc5-1.0.1/theories/separation-logic.html
@@ -201,6 +201,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -210,11 +220,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/sequences.html
+++ b/cvc5-1.0.1/theories/sequences.html
@@ -191,6 +191,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -200,11 +210,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/sets-and-relations.html
+++ b/cvc5-1.0.1/theories/sets-and-relations.html
@@ -195,6 +195,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -204,11 +214,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/strings.html
+++ b/cvc5-1.0.1/theories/strings.html
@@ -181,6 +181,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -190,11 +200,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/theories.html
+++ b/cvc5-1.0.1/theories/theories.html
@@ -211,6 +211,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -220,11 +230,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.1/theories/transcendentals.html
+++ b/cvc5-1.0.1/theories/transcendentals.html
@@ -203,6 +203,16 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.2/">
+         cvc5-1.0.2
+        </a>
+       </dd>
+       <dd>
         <strong>
          <a href="../../cvc5-1.0.1/">
           cvc5-1.0.1
@@ -212,11 +222,6 @@
        <dd>
         <a href="../../cvc5-1.0.0/">
          cvc5-1.0.0
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.2/">
-         cvc5-1.0.2
         </a>
        </dd>
       </dl>

--- a/cvc5-1.0.2/api/api.html
+++ b/cvc5-1.0.2/api/api.html
@@ -142,13 +142,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -157,6 +152,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/cpp.html
+++ b/cvc5-1.0.2/api/cpp/cpp.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/datatype.html
+++ b/cvc5-1.0.2/api/cpp/datatype.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/datatypeconstructor.html
+++ b/cvc5-1.0.2/api/cpp/datatypeconstructor.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/datatypeconstructordecl.html
+++ b/cvc5-1.0.2/api/cpp/datatypeconstructordecl.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/datatypedecl.html
+++ b/cvc5-1.0.2/api/cpp/datatypedecl.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/datatypeselector.html
+++ b/cvc5-1.0.2/api/cpp/datatypeselector.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/driveroptions.html
+++ b/cvc5-1.0.2/api/cpp/driveroptions.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/exceptions.html
+++ b/cvc5-1.0.2/api/cpp/exceptions.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/grammar.html
+++ b/cvc5-1.0.2/api/cpp/grammar.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/kind.html
+++ b/cvc5-1.0.2/api/cpp/kind.html
@@ -259,13 +259,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -274,6 +269,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/modes.html
+++ b/cvc5-1.0.2/api/cpp/modes.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/op.html
+++ b/cvc5-1.0.2/api/cpp/op.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/optioninfo.html
+++ b/cvc5-1.0.2/api/cpp/optioninfo.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/quickstart.html
+++ b/cvc5-1.0.2/api/cpp/quickstart.html
@@ -268,13 +268,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -283,6 +278,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/result.html
+++ b/cvc5-1.0.2/api/cpp/result.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/roundingmode.html
+++ b/cvc5-1.0.2/api/cpp/roundingmode.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/solver.html
+++ b/cvc5-1.0.2/api/cpp/solver.html
@@ -259,13 +259,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -274,6 +269,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/sort.html
+++ b/cvc5-1.0.2/api/cpp/sort.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/statistics.html
+++ b/cvc5-1.0.2/api/cpp/statistics.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/synthresult.html
+++ b/cvc5-1.0.2/api/cpp/synthresult.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/term.html
+++ b/cvc5-1.0.2/api/cpp/term.html
@@ -259,13 +259,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -274,6 +269,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/cpp/unknownexplanation.html
+++ b/cvc5-1.0.2/api/cpp/unknownexplanation.html
@@ -254,13 +254,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -269,6 +264,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/java/java.html
+++ b/cvc5-1.0.2/api/java/java.html
@@ -164,13 +164,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -179,6 +174,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/java/quickstart.html
+++ b/cvc5-1.0.2/api/java/quickstart.html
@@ -178,13 +178,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -193,6 +188,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/datatype.html
+++ b/cvc5-1.0.2/api/python/base/datatype.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/datatypeconstructor.html
+++ b/cvc5-1.0.2/api/python/base/datatypeconstructor.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/datatypeconstructordecl.html
+++ b/cvc5-1.0.2/api/python/base/datatypeconstructordecl.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/datatypedecl.html
+++ b/cvc5-1.0.2/api/python/base/datatypedecl.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/datatypeselector.html
+++ b/cvc5-1.0.2/api/python/base/datatypeselector.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/grammar.html
+++ b/cvc5-1.0.2/api/python/base/grammar.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/kind.html
+++ b/cvc5-1.0.2/api/python/base/kind.html
@@ -256,13 +256,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -271,6 +266,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/op.html
+++ b/cvc5-1.0.2/api/python/base/op.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/python.html
+++ b/cvc5-1.0.2/api/python/base/python.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/quickstart.html
+++ b/cvc5-1.0.2/api/python/base/quickstart.html
@@ -265,13 +265,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -280,6 +275,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/result.html
+++ b/cvc5-1.0.2/api/python/base/result.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/roundingmode.html
+++ b/cvc5-1.0.2/api/python/base/roundingmode.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/solver.html
+++ b/cvc5-1.0.2/api/python/base/solver.html
@@ -256,13 +256,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -271,6 +266,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/sort.html
+++ b/cvc5-1.0.2/api/python/base/sort.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/statistics.html
+++ b/cvc5-1.0.2/api/python/base/statistics.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/synthresult.html
+++ b/cvc5-1.0.2/api/python/base/synthresult.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/term.html
+++ b/cvc5-1.0.2/api/python/base/term.html
@@ -256,13 +256,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -271,6 +266,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/base/unknownexplanation.html
+++ b/cvc5-1.0.2/api/python/base/unknownexplanation.html
@@ -251,13 +251,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -266,6 +261,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/python.html
+++ b/cvc5-1.0.2/api/python/python.html
@@ -164,13 +164,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -179,6 +174,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/arith.html
+++ b/cvc5-1.0.2/api/python/pythonic/arith.html
@@ -253,13 +253,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -268,6 +263,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/array.html
+++ b/cvc5-1.0.2/api/python/pythonic/array.html
@@ -243,13 +243,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -258,6 +253,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/bitvec.html
+++ b/cvc5-1.0.2/api/python/pythonic/bitvec.html
@@ -248,13 +248,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -263,6 +258,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/boolean.html
+++ b/cvc5-1.0.2/api/python/pythonic/boolean.html
@@ -253,13 +253,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -268,6 +263,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/dt.html
+++ b/cvc5-1.0.2/api/python/pythonic/dt.html
@@ -238,13 +238,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -253,6 +248,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/fp.html
+++ b/cvc5-1.0.2/api/python/pythonic/fp.html
@@ -248,13 +248,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -263,6 +258,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/internals.html
+++ b/cvc5-1.0.2/api/python/pythonic/internals.html
@@ -233,13 +233,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -248,6 +243,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/pythonic.html
+++ b/cvc5-1.0.2/api/python/pythonic/pythonic.html
@@ -221,13 +221,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -236,6 +231,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/quant.html
+++ b/cvc5-1.0.2/api/python/pythonic/quant.html
@@ -238,13 +238,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -253,6 +248,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/quickstart.html
+++ b/cvc5-1.0.2/api/python/pythonic/quickstart.html
@@ -235,13 +235,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -250,6 +245,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/set.html
+++ b/cvc5-1.0.2/api/python/pythonic/set.html
@@ -238,13 +238,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -253,6 +248,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/api/python/pythonic/solver.html
+++ b/cvc5-1.0.2/api/python/pythonic/solver.html
@@ -243,13 +243,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -258,6 +253,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/binary/binary.html
+++ b/cvc5-1.0.2/binary/binary.html
@@ -132,13 +132,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -147,6 +142,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/binary/quickstart.html
+++ b/cvc5-1.0.2/binary/quickstart.html
@@ -146,13 +146,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -161,6 +156,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/bags.html
+++ b/cvc5-1.0.2/examples/bags.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/bitvectors.html
+++ b/cvc5-1.0.2/examples/bitvectors.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/bitvectors_and_arrays.html
+++ b/cvc5-1.0.2/examples/bitvectors_and_arrays.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/combination.html
+++ b/cvc5-1.0.2/examples/combination.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/datatypes.html
+++ b/cvc5-1.0.2/examples/datatypes.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/examples.html
+++ b/cvc5-1.0.2/examples/examples.html
@@ -222,13 +222,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -237,6 +232,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/exceptions.html
+++ b/cvc5-1.0.2/examples/exceptions.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/extract.html
+++ b/cvc5-1.0.2/examples/extract.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/floatingpoint.html
+++ b/cvc5-1.0.2/examples/floatingpoint.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/helloworld.html
+++ b/cvc5-1.0.2/examples/helloworld.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/lineararith.html
+++ b/cvc5-1.0.2/examples/lineararith.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/quickstart.html
+++ b/cvc5-1.0.2/examples/quickstart.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/relations.html
+++ b/cvc5-1.0.2/examples/relations.html
@@ -229,13 +229,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -244,6 +239,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/sequences.html
+++ b/cvc5-1.0.2/examples/sequences.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/sets.html
+++ b/cvc5-1.0.2/examples/sets.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/strings.html
+++ b/cvc5-1.0.2/examples/strings.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/sygus-fun.html
+++ b/cvc5-1.0.2/examples/sygus-fun.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/sygus-grammar.html
+++ b/cvc5-1.0.2/examples/sygus-grammar.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/examples/sygus-inv.html
+++ b/cvc5-1.0.2/examples/sygus-inv.html
@@ -224,13 +224,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -239,6 +234,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/genindex.html
+++ b/cvc5-1.0.2/genindex.html
@@ -124,13 +124,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -139,6 +134,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/index.html
+++ b/cvc5-1.0.2/index.html
@@ -124,13 +124,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -139,6 +134,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/installation/installation.html
+++ b/cvc5-1.0.2/installation/installation.html
@@ -272,13 +272,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -287,6 +282,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/options.html
+++ b/cvc5-1.0.2/options.html
@@ -244,13 +244,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -259,6 +254,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/output-tags.html
+++ b/cvc5-1.0.2/output-tags.html
@@ -182,13 +182,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -197,6 +192,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/proofs/output_alethe.html
+++ b/cvc5-1.0.2/proofs/output_alethe.html
@@ -147,13 +147,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -162,6 +157,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/proofs/output_dot.html
+++ b/cvc5-1.0.2/proofs/output_dot.html
@@ -147,13 +147,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -162,6 +157,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/proofs/output_lfsc.html
+++ b/cvc5-1.0.2/proofs/output_lfsc.html
@@ -147,13 +147,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -162,6 +157,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/proofs/proof_rules.html
+++ b/cvc5-1.0.2/proofs/proof_rules.html
@@ -152,13 +152,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -167,6 +162,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/proofs/proofs.html
+++ b/cvc5-1.0.2/proofs/proofs.html
@@ -147,13 +147,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -162,6 +157,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/references.html
+++ b/cvc5-1.0.2/references.html
@@ -125,13 +125,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -140,6 +135,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/resource-limits.html
+++ b/cvc5-1.0.2/resource-limits.html
@@ -141,13 +141,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -156,6 +151,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/search.html
+++ b/cvc5-1.0.2/search.html
@@ -128,13 +128,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -143,6 +138,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/statistics.html
+++ b/cvc5-1.0.2/statistics.html
@@ -125,13 +125,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="./../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="./../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -140,6 +135,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="./../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/bags.html
+++ b/cvc5-1.0.2/theories/bags.html
@@ -195,13 +195,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -210,6 +205,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/datatypes.html
+++ b/cvc5-1.0.2/theories/datatypes.html
@@ -226,13 +226,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -241,6 +236,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/separation-logic.html
+++ b/cvc5-1.0.2/theories/separation-logic.html
@@ -201,13 +201,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -216,6 +211,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/sequences.html
+++ b/cvc5-1.0.2/theories/sequences.html
@@ -191,13 +191,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -206,6 +201,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/sets-and-relations.html
+++ b/cvc5-1.0.2/theories/sets-and-relations.html
@@ -195,13 +195,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -210,6 +205,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/strings.html
+++ b/cvc5-1.0.2/theories/strings.html
@@ -181,13 +181,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -196,6 +191,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/theories.html
+++ b/cvc5-1.0.2/theories/theories.html
@@ -211,13 +211,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -226,6 +221,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>

--- a/cvc5-1.0.2/theories/transcendentals.html
+++ b/cvc5-1.0.2/theories/transcendentals.html
@@ -203,13 +203,8 @@
      <div class="rst-other-versions">
       <dl>
        <dd>
-        <a href="../../cvc5-1.0.1/">
-         cvc5-1.0.1
-        </a>
-       </dd>
-       <dd>
-        <a href="../../cvc5-1.0.0/">
-         cvc5-1.0.0
+        <a href="https://cvc5.github.io/docs-ci/docs-main/">
+         cvc5-main
         </a>
        </dd>
        <dd>
@@ -218,6 +213,16 @@
           cvc5-1.0.2
          </a>
         </strong>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.1/">
+         cvc5-1.0.1
+        </a>
+       </dd>
+       <dd>
+        <a href="../../cvc5-1.0.0/">
+         cvc5-1.0.0
+        </a>
        </dd>
       </dl>
      </div>


### PR DESCRIPTION
This adds a link to the latest version of the documentation. A link back
to the existing documentations will be added in a future change on the
main cvc5 repository.