### PR TITLE
Remove unused StrictVersion import from distutils

### DIFF
--- a/genversions.py
+++ b/genversions.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from bs4 import BeautifulSoup
-from distutils.version import StrictVersion
 import copy
 import glob
 import jinja2


### PR DESCRIPTION
The `genversions.py` script triggered a `DeprecationWarning` due to the use of the `distutils` module, which is deprecated and slated for removal in Python 3.12. Although `StrictVersion` was imported, it was not being used in the script, so the import was removed to eliminate the warning and future-proof the code.